### PR TITLE
add page 404

### DIFF
--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -19,7 +19,12 @@ import {
 import { DoughnutChart, LineChart, Table } from "./dashboard";
 
 // Project Import
-import { ProjectScaffold, Dropbox, SubmitProjectModal } from "./project";
+import {
+  ProjectScaffold,
+  Dropbox,
+  SubmitProjectModal,
+  LogoCanvas,
+} from "./project";
 
 export {
   IntroSection,
@@ -38,4 +43,5 @@ export {
   Notification,
   Dropbox,
   SubmitProjectModal,
+  LogoCanvas,
 };

--- a/frontend/components/project/index.ts
+++ b/frontend/components/project/index.ts
@@ -2,4 +2,7 @@ import ProjectScaffold from "./ProjectScaffold";
 import Dropbox from "./Dropbox";
 import SubmitProjectModal from "./SubmitProjectModal";
 
-export { ProjectScaffold, Dropbox, SubmitProjectModal };
+// 3d Imports
+import { LogoCanvas } from "./3d";
+
+export { ProjectScaffold, Dropbox, SubmitProjectModal, LogoCanvas };

--- a/frontend/constants/index.ts
+++ b/frontend/constants/index.ts
@@ -16,7 +16,7 @@ import {
   FeaturesInterface,
   SupportInterface,
   CreateProjectFieldInterface,
-  TypeDataDomainInterface
+  TypeDataDomainInterface,
 } from "../interfaces";
 
 // Types Imports
@@ -25,9 +25,10 @@ import { ProjectDetailInterfaceKeysType } from "../types";
 // Mock Data Import
 import { mockData } from "./mockData";
 
-export { mockData }
+export { mockData };
 
-export const waitlistUrl: string = "https://docs.google.com/forms/d/e/1FAIpQLSfe3r7ia_OTCHU8tHEtNG_aPY6OpLDsLPl3RDj-wQLutXNTKg/viewform";
+export const waitlistUrl: string =
+  "https://docs.google.com/forms/d/e/1FAIpQLSfe3r7ia_OTCHU8tHEtNG_aPY6OpLDsLPl3RDj-wQLutXNTKg/viewform";
 
 export const navLinks = [
   {
@@ -45,24 +46,27 @@ export const navLinks = [
   {
     id: "support",
     title: "Support",
-  }
+  },
 ];
 
 export const currentSystemProblems: ProblemsInterface[] = [
   {
     id: "Escrow",
     image: Escrow,
-    description: "You can securely conduct transactions using Qube, even when dealing with anonymous individuals.",
+    description:
+      "You can securely conduct transactions using Qube, even when dealing with anonymous individuals.",
   },
   {
     id: "Community",
     image: Community,
-    description: "Not only can Qube be used for one-on-one transactions, but it is also suitable for assigning tasks to community members.",
+    description:
+      "Not only can Qube be used for one-on-one transactions, but it is also suitable for assigning tasks to community members.",
   },
   {
     id: "API",
     image: API,
-    description: "With Qube's developer tools, anyone will be able to easily build applications similar to Qube. (Coming soon)",
+    description:
+      "With Qube's developer tools, anyone will be able to easily build applications similar to Qube. (Coming soon)",
   },
 ];
 
@@ -341,6 +345,27 @@ export const aesthetics = {
         width: "200px",
         height: "200px",
         filter: "blur(200px)",
+        transform: "translateY(-50%)",
+      },
+    ],
+
+    pageNotFoundStyles: [
+      {
+        backgroundColor: "#00FFFF",
+        top: "50%",
+        left: "17%",
+        width: "250px",
+        height: "250px",
+        filter: "blur(250px)",
+        transform: "translateY(-50%)",
+      },
+      {
+        backgroundColor: "#2563EB",
+        top: "50%",
+        right: "35%",
+        width: "250px",
+        height: "250px",
+        filter: "blur(250px)",
         transform: "translateY(-50%)",
       },
     ],

--- a/frontend/pages/404.tsx
+++ b/frontend/pages/404.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+
+// Interface Imports
+import { SectionWrapperPropsInterface } from "../interfaces";
+
+// Custom Component Imports
+import { CustomButton, Glow, LogoCanvas } from "../components";
+
+// Framer Motion Imports
+import { motion } from "framer-motion";
+
+// Constant Imports
+import { aesthetics } from "../constants";
+import { useRouter } from "next/router";
+
+const SectionWrapper: React.FC<SectionWrapperPropsInterface> = ({
+  children,
+  bgColor,
+  glowStyles,
+}): JSX.Element => {
+  return (
+    <motion.div
+      className={`w-full grid grid-cols-12 ${bgColor} xl:py-40 lg:py-32 py-28 overflow-hidden relative min-h-screen font-nunito`}
+    >
+      {glowStyles && <Glow styles={glowStyles} />}
+      <div className="col-start-2 col-end-12 font-semibold relative flex flex-col justify-center">
+        {children}
+      </div>
+    </motion.div>
+  );
+};
+
+const PageNotFound = () => {
+  const router = useRouter();
+
+  return (
+    <SectionWrapper
+      bgColor="bg-bg_primary"
+      glowStyles={aesthetics.glow.pageNotFoundStyles}
+    >
+      <div className="block lg:flex flex-row items-center gap-16 text-white font-nunito">
+        {/* 404 Message */}
+        <div className=" flex flex-col items-center gap-12">
+          {/* Wrapper Heading */}
+          <div className="flex flex-col items-center">
+            {/* Heading */}
+            <h1 className=" lg:text-[150px] xl:text-[200px] sm:text-[150px] text-[100px] lg:leading-[150px] xl:leading-[200px] sm:leading-[150px] leading-[100px] linear-green-blue-gradient font-extrabold">
+              404
+            </h1>
+            {/* Sub-Heading */}
+            <h2 className="lg:text-5xl xl:text-6xl sm:text-6xl xs:text-4xl text-3xl font-bold">
+              PAGE NOT FOUND
+            </h2>
+          </div>
+          {/* Wrapper Message */}
+          <div className="flex flex-col items-center">
+            <p className="lg:text-2xl xs:text-xl text-lg font-medium text-[#a1a1a1] text-center">
+              The page you are looking for was moved, removed, renamed or might
+              never existed.
+            </p>
+          </div>
+          {/* Home Button */}
+          <CustomButton
+            text="Back to Home"
+            styles="bg-[#3E8ECC] rounded-md text-center xl:text-2xl font-semibold text-white py-[8px] px-12 hover:bg-[#377eb5]"
+            type="button"
+            onClick={() => {
+              router.push("/");
+            }}
+          />
+        </div>
+        {/* 3D Logo */}
+
+        <div className="w-1/3 h-[500px] lg:block hidden">
+          <LogoCanvas />
+        </div>
+      </div>
+    </SectionWrapper>
+  );
+};
+
+export default PageNotFound;

--- a/frontend/pages/createProject.tsx
+++ b/frontend/pages/createProject.tsx
@@ -6,7 +6,7 @@ import { ProjectScaffold } from "../components";
 const CreateProject: NextPage = () => {
   const [showSubmitModal, setShowSubmitModal] = useState(false);
 
-  return <ProjectScaffold setShowSubmitModal={setShowSubmitModal}/>;
-}
+  return <ProjectScaffold setShowSubmitModal={setShowSubmitModal} />;
+};
 
 export default CreateProject;

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -11,6 +11,14 @@
   text-fill-color: transparent;
 }
 
+.linear-green-blue-gradient {
+  background: linear-gradient(100.74deg, #00ffff , #2563EB );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  text-fill-color: transparent;
+}
+
 .progressBar {
   background: linear-gradient(to right, #2563eb, #00ffff);
 }


### PR DESCRIPTION
# Description
This pull request specifically resolves #36 

# Info

This pull request introduces a custom **404 page**.

# Images
## Desktop 404 Page
![image](https://github.com/Succery-dev/QubePay/assets/94784612/3744e02b-0992-4f62-8216-2f7c59cdea71)

## Mobile 404 Page
![image](https://github.com/Succery-dev/QubePay/assets/94784612/225d5628-9b4d-45eb-8396-055e1ed3efc9)

# Type of Change

## File constants/index.ts
added `pageNotFoundStyles`  in  `aesthetics` that give styles to the `Glow` component for **page 404**.

## File pages/404.tsx
1. Added file `404.tsx`. Will be rendered whenever the user tries to go to a page that does not exist.
2. This also has a `button` "**Back to Home**" that redirects the user back to the Home page.

## File globals.css
Added style for class `linear-green-blue-gradient`. This makes the text have a color gradient over a single-solid color. This class is applied to tag `h1` which renders text "**404**" in **pages/404.tsx**.



